### PR TITLE
Allow 3-dimensional array to pass through to imagecodecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Enable JPEG encoding of zarr / n5 chunks. Only tested with 2D or 3D `uint8` nume
 ### Usage
 
 Stand-alone:
-```python
+```python3
 from zarr_jpeg import jpeg
 import numpy as np
 data = np.random.randint((100,255), (100,100,100), dtype='uint8')
@@ -16,11 +16,22 @@ encoded = codec.encode(data)
 decoded = codec.decode(encoded).reshape(data.shape)
 ```
 With zarr:
-```python
+```python3
 from zarr_jpeg import jpeg
 import zarr
 array = zarr.open_array('foo/bar.zarr', path='path/to/array', compressor=jpeg(quality=50), shape=(100,100,100), dtype='uint8')
 ```
+
+Note that if an image has more than two dimensions then all but the last dimension are collapsed together to make a two-dimensional image to be encoded.  For example, an image with shape (10, 200, 3000) is encoded as the shape (2000, 3000).  However the collapsing can be suppressed with:
+
+```python3
+codec = jpeg(quality=100, axis_reduction=None)
+```
+Alternatively, the collapsing can be specified explicitly.  For example:
+```python3
+codec = jpeg(quality=100, axis_reduction=[[0], [1, 2], [3, 4, 5]])
+```
+reshapes the shape (2, 3, 4, 5, 6, 7) to (2, 12, 210).
 
 ### References
 This repo is inspired by the [neuroglancer "precomputed" format](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/volume.md), which uses jpeg encoding to compress chunks of imaging data.

--- a/src/zarr_jpeg/zarr_jpeg.py
+++ b/src/zarr_jpeg/zarr_jpeg.py
@@ -10,13 +10,14 @@ class jpeg(Codec):
     Parameters
     ----------
     quality : int
-        Compression level. 
+        Compression level.
     """
 
     codec_id = "jpeg"
 
-    def __init__(self, quality=100):
+    def __init__(self, quality=100, axis_reduction='collapse'):
         self.quality = quality
+        self.axis_reduction = axis_reduction
         assert (
             self.quality > 0 and self.quality <= 100 and isinstance(self.quality, int)
         )
@@ -24,11 +25,25 @@ class jpeg(Codec):
 
     def encode(self, buf):
         bufa = ensure_ndarray(buf)
-        assert bufa.ndim == 2 or bufa.ndim == 3
-        if bufa.ndim == 3:
-            tiled = bufa.reshape(bufa.shape[0] * bufa.shape[1], -1)
-        else:
+        assert bufa.ndim >= 2
+        axis_reduction = self.axis_reduction
+        if isinstance(axis_reduction, str) and axis_reduction == 'collapse':
+            if bufa.ndim >= 3:
+                # all but the last dimension are collapsed into first dimension, followed by last dimension
+                axis_reduction = [[dim for dim in range(bufa.ndim - 1)]]
+                axis_reduction.append([bufa.ndim - 1])
+            else:
+                # keep each dimension as is.
+                axis_reduction = None
+
+        if axis_reduction is None:
             tiled = bufa
+        else:
+            # Check that each dimension is mentioned exactly once, in order.
+            assert [dim for axis in axis_reduction for dim in axis] == [dim for dim in range(buf.ndim)]
+            # Reshape using the axis_reduction
+            tiled = bufa.reshape([np.prod([bufa.shape[dim] for dim in axis], dtype='uint') for axis in axis_reduction])
+
         return jpeg_encode(tiled, level=self.quality)
 
     def decode(self, buf, out=None):


### PR DESCRIPTION
The underlying `imagecodecs.jpeg_encode` can handle a 3-dimensional array.  The current implementation of reshaping a 3-dimensional array to 2 dimensions, by multiplying the extents of the first two dimensions, fails when that product exceeds 655,360.
