### PR TITLE
Axis reduction cleanup

### DIFF
--- a/src/zarr_jpeg/zarr_jpeg.py
+++ b/src/zarr_jpeg/zarr_jpeg.py
@@ -2,6 +2,20 @@ from numcodecs.abc import Codec
 from numcodecs.compat import ensure_ndarray, ensure_contiguous_ndarray, ndarray_copy
 from numcodecs.registry import register_codec
 from imagecodecs import jpeg_encode, jpeg_decode
+import numpy as np
+from typing import List, Any, Union
+
+JPEG_MAX_DIMENSION = 655_000
+
+def validate_axis_reduction(axis_reduction: Any, rank: int) -> List[List[Union[int, str]]]:
+    result = [[], [], []]
+    if rank < 2: 
+        raise ValueError(f'Invalid rank. Rank must be greater than 1; got rank={rank}')
+    if axis_reduction is None:
+        result
+    else:
+        pass
+    return result
 
 
 class jpeg(Codec):
@@ -28,10 +42,9 @@ class jpeg(Codec):
         assert bufa.ndim >= 2
         axis_reduction = self.axis_reduction
         if isinstance(axis_reduction, str) and axis_reduction == 'collapse':
-            if bufa.ndim >= 3:
+            if bufa.ndim > 2:
                 # all but the last dimension are collapsed into first dimension, followed by last dimension
-                axis_reduction = [[dim for dim in range(bufa.ndim - 1)]]
-                axis_reduction.append([bufa.ndim - 1])
+                axis_reduction = [[dim for dim in range(bufa.ndim - 1)], [bufa.ndim - 1]]
             else:
                 # keep each dimension as is.
                 axis_reduction = None


### PR DESCRIPTION
This PR elaborates on the recent addition of the `axis_reduction` keyword argument to the `jpeg` compression codec. See https://github.com/d-v-b/zarr-jpeg/pull/1 for the original discussion of that topic.

I discovered that the current strategy of axis reduction does not handle singleton axes correctly, which can lead to invalid inputs to `jpeg_encode`. For example, if input chunks have shape = (512,512,1), multiplying the first two axes and keeping the last will result in a buffer with shape (512 ** 2, 1) being passed into `jpeg_encode`. It would be ideal to catch these problems _before_ we call `jpeg.encode()`, i.e. at codec creation time. This PR adds a `input_shape` parameter to the `jpeg` constructor that allows sensible automatic creation of the `axis_reduction` property before calling `jpeg.encode()`. I also added a new function, `validate_axis_reduction(input_shape, axis_reduction)`, that a) creates a sensible default `axis_reduction` if called with `axis_reduction=None`, and b) validates that `axis _reduction` against the supplied `input_shape`

Examples:

```python
validate_axis_reduction(input_shape=(10,), axis_reduction=None)
ValueError: Invalid input_shape. input_shape must have have length 2 or greater; got input_shape with length = 1
```

```python
validate_axis_reduction(input_shape=(10,10), axis_reduction=None)
((0,), (1,), ())
```

```python
validate_axis_reduction((10,10), ((0,), (1,), (2,)))
ValueError: Invalid axis_reduction. axis_reduction must contain (0, 1). Got axis_reduction that contained (0, 1, 2) instead.
```

```python
validate_axis_reduction((1, 10, 10, 10, 1), None)
# singleton dimensions are collected in the first element of axis_reduction
((1, 2, 0, 4), (3,), ())
```

We want to perform this validation at codec creation time because we want all the codec metadata (including `axis_reduction`) to be instantiated and serializable at codec creation time. The cost of this approach is that instances of `jpeg` must be created with a specific input_shape, i.e. `jpeg(input_shape=(10,10,10))` will not work for encoding arrays with an input_shape of (10,10). 

Additionally, `axis_reduction` has been changed from a list of lists to a tuple of tuples, in order to be stricter about mutability. 

In the future, `validate_axis_reduction` can take into account the maximum height / width constraint of `jpeg_encode` and attempt to automatically arrange `axis_reduction` to avoid a height or width that exceeds 655000.

cc @Leengit 